### PR TITLE
Raise exception on pull_translations failure

### DIFF
--- a/lib/pull_translations.rb
+++ b/lib/pull_translations.rb
@@ -5,8 +5,9 @@ module PullTranslations
 
   def run
     5.times do
-      system("wti pull -c config/translation.yml")
-      system("wti pull -c config/questionnaire_translation.yml")
+      system("wti pull -c config/translation.yml") || fail("Failed to pull system translations")
+      system("wti pull -c config/questionnaire_translation.yml") || fail("Failed to pull questionnaire translations")
+
       begin
         WTISanity.check
         break

--- a/lib/pull_translations.rb
+++ b/lib/pull_translations.rb
@@ -5,17 +5,15 @@ module PullTranslations
 
   def run
     5.times do
-      system("wti pull -c config/translation.yml") || fail("Failed to pull system translations")
-      system("wti pull -c config/questionnaire_translation.yml") || fail("Failed to pull questionnaire translations")
-
       begin
+        system("wti pull -c config/translation.yml") || raise("Failed to pull system translations")
+        system("wti pull -c config/questionnaire_translation.yml") || raise("Failed to pull questionnaire translations")
+
         WTISanity.check
         break
-      rescue StandardError
-        puts "retrying translation pull"
+      rescue StandardError => ex
+        puts "retrying translation pull: #{ex.message}"
       end
     end
-
-    WTISanity.check
   end
 end

--- a/lib/pull_translations.rb
+++ b/lib/pull_translations.rb
@@ -5,8 +5,8 @@ module PullTranslations
 
   def run
     5.times do
-      system("wti pull -c config/translation.yml")
-      system("wti pull -c config/questionnaire_translation.yml")
+      run("wti pull -c config/translation.yml")
+      run("wti pull -c config/questionnaire_translation.yml")
       begin
         WTISanity.check
         break

--- a/lib/pull_translations.rb
+++ b/lib/pull_translations.rb
@@ -5,8 +5,8 @@ module PullTranslations
 
   def run
     5.times do
-      run("wti pull -c config/translation.yml")
-      run("wti pull -c config/questionnaire_translation.yml")
+      system("wti pull -c config/translation.yml")
+      system("wti pull -c config/questionnaire_translation.yml")
       begin
         WTISanity.check
         break

--- a/pull_translations.gemspec
+++ b/pull_translations.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "pull_translations"
-  s.version     = "0.1.1"
+  s.version     = "0.1.0"
   s.platform    = Gem::Platform::RUBY
   s.author      = "developers@reevoo.com"
   s.email       = "developers@reevoo.com"

--- a/pull_translations.gemspec
+++ b/pull_translations.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "pull_translations"
-  s.version     = "0.1.0"
+  s.version     = "0.1.2"
   s.platform    = Gem::Platform::RUBY
   s.author      = "developers@reevoo.com"
   s.email       = "developers@reevoo.com"

--- a/pull_translations.gemspec
+++ b/pull_translations.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "pull_translations"
-  s.version     = "0.1.0"
+  s.version     = "0.1.1"
   s.platform    = Gem::Platform::RUBY
   s.author      = "developers@reevoo.com"
   s.email       = "developers@reevoo.com"

--- a/pull_translations.gemspec
+++ b/pull_translations.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "pull_translations"
-  s.version     = "0.1.2"
+  s.version     = "0.1.3"
   s.platform    = Gem::Platform::RUBY
   s.author      = "developers@reevoo.com"
   s.email       = "developers@reevoo.com"


### PR DESCRIPTION
Kernel.system returns true/false
Capistrano's #run raises exception if something goes wrong

We have to use 'run' otherwise the deployment script will not catch the
error and the app may be deployed with broken translation files.